### PR TITLE
feat: Uprev nalgebra and implement Copy trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "spade"
 version = "1.8.2"
 authors = ["Stefan Altmayer <stoeoef@gmail.com>"]
-description="Spatial datastructures like r-trees and delaunay triangulations for rust."
+description = "Spatial datastructures like r-trees and delaunay triangulations for rust."
 documentation = "https://docs.rs/spade/"
 repository = "https://github.com/Stoeoef/spade"
 readme = "README.md"
@@ -14,14 +14,14 @@ edition = "2018"
 serde_serialize = ["num/serde", "serde"]
 
 [dependencies]
-nalgebra = ">=0.11.0, <=0.18.*"
+nalgebra = "0.33.2"
 cgmath = "0.18"
 num = ">= 0.1.0, <=0.2.*"
 clamp = "0.1"
 smallvec = "1.2"
 pdqselect = "0.1"
-serde_derive = { version = "1.0", optional=true }
-serde = { version = "1.0", optional=true, features=["rc", "serde_derive"] }
+serde_derive = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["rc", "serde_derive"] }
 
 [dev-dependencies]
 rand = "0.7"

--- a/src/bigvec.rs
+++ b/src/bigvec.rs
@@ -479,7 +479,7 @@ where
 
 impl<I> From<na::Point2<I>> for BigVec2<AdaptiveInt>
 where
-    I: ::std::convert::Into<i64> + na::Scalar,
+    I: ::std::convert::Into<i64> + na::Scalar + Copy,
 {
     fn from(v: na::Point2<I>) -> Self {
         BigVec2::new(

--- a/src/point_traits.rs
+++ b/src/point_traits.rs
@@ -155,7 +155,7 @@ impl<T> PointNExtensions for T where T: PointN {}
 pub trait TwoDimensional: PointN {}
 
 impl<S: SpadeNum + cg::BaseNum> TwoDimensional for cg::Point2<S> {}
-impl<S: SpadeNum + na::Scalar> TwoDimensional for na::Point2<S> {}
+impl<S: SpadeNum + na::Scalar + Copy> TwoDimensional for na::Point2<S> {}
 impl<S: SpadeNum + Copy> TwoDimensional for [S; 2] {}
 
 /// A three dimensional Point.
@@ -178,7 +178,7 @@ pub trait ThreeDimensional: PointN {
 
 impl<S: SpadeNum + cg::BaseNum> ThreeDimensional for cg::Point3<S> {}
 
-impl<S: SpadeNum + na::Scalar> ThreeDimensional for na::Point3<S> {}
+impl<S: SpadeNum + na::Scalar + Copy> ThreeDimensional for na::Point3<S> {}
 
 impl<S: SpadeNum + Copy> ThreeDimensional for [S; 3] {}
 
@@ -275,7 +275,7 @@ impl<S: SpadeNum + cg::BaseNum> PointN for cg::Point3<S> {
     }
 }
 
-impl<S: SpadeNum + na::Scalar> PointN for na::Point2<S> {
+impl<S: SpadeNum + na::Scalar + Copy> PointN for na::Point2<S> {
     type Scalar = S;
 
     fn dimensions() -> usize {
@@ -294,7 +294,7 @@ impl<S: SpadeNum + na::Scalar> PointN for na::Point2<S> {
     }
 }
 
-impl<S: SpadeNum + na::Scalar> PointN for na::Point3<S> {
+impl<S: SpadeNum + na::Scalar + Copy> PointN for na::Point3<S> {
     type Scalar = S;
 
     fn dimensions() -> usize {
@@ -313,7 +313,7 @@ impl<S: SpadeNum + na::Scalar> PointN for na::Point3<S> {
     }
 }
 
-impl<S: SpadeNum + na::Scalar + na::Scalar> PointN for na::Point4<S> {
+impl<S: SpadeNum + na::Scalar + na::Scalar + std::marker::Copy> PointN for na::Point4<S> {
     type Scalar = S;
 
     fn dimensions() -> usize {


### PR DESCRIPTION
## Related Issues

https://decatechnologies.atlassian.net/browse/APS-2250

## Information

nalgebra crate is upgraded to 0.33.2 to mitigate one of the critical SBOM vulnerabilities. Look [here](https://github.com/Deca-Technologies/Microlite/blob/edc4bd3e4a1f30e1fe7455e3c4c8a175d3a277d7/doc/vulnerability_analysis/sbom-analysis.md) for more details. 

When the nalgebra crate was upgraded, one of the traits stopped deriving Copy. The PointN struct now derives Copy as part of this PR. This was needed as the struct value is passed many times into a function and to keep the borrow checker happy, either the value needed to be cloned or use the Copy trait.

To make sure nothing broke, I ran existing tests in the germanium and zinc repositories with the updated spade crate branch and nothing failed.